### PR TITLE
Allow rune char for microsecond

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,4 @@
-Copyright 2018-2020 Jon Inge Moe
+Copyright 2018-2024 Jon Inge Moe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If no unit is given it will assume that the value is in seconds
 ## Units
 `ns` // nanoseconds  
 `us` // microseconds  
+`µs` // microseconds  
 `ms` // milliseconds  
 `s` // seconds  
 `m` // minutes  
@@ -29,4 +30,5 @@ If no unit is given it will assume that the value is in seconds
 `timeperiod.Milliseconds("5m")` // 300000  
 `timeperiod.Microconds("1h")` // 3600000000  
 `timeperiod.Nanoseconds("1us")` // 1000  
+`timeperiod.Nanoseconds("1µs")` // 1000  
 `timeperiod.Duration("5ns")` // 5  

--- a/convert_test.go
+++ b/convert_test.go
@@ -1,0 +1,40 @@
+package timeperiod
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConvert(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Duration
+		ok       bool
+	}{
+		{"nanoseconds", "7ns", 7 * time.Nanosecond, true},
+		{"microseconds u", "77us", 77 * time.Microsecond, true},
+		{"microseconds µ", "66µs", 66 * time.Microsecond, true},
+		{"milliseconds", "15ms", 15 * time.Millisecond, true},
+		{"seconds", "1s", 1 * time.Second, true},
+		{"no unit", "8", 8 * time.Second, true},
+		{"minutes", "2m", 2 * time.Minute, true},
+		{"hours", "3h", 3 * time.Hour, true},
+		{"days", "4d", 4 * 24 * time.Hour, true},
+		{"weeks", "1w", 7 * 24 * time.Hour, true},
+		{"string", "invalid", 0, false},
+		{"number and string", "12invalid", 0, false},
+		{"string and number", "invalid99", 0, false},
+		{"empty string", "", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dur, ok := convert(tt.input)
+			if dur != tt.expected || ok != tt.ok {
+				t.Errorf("convert(%q) = %v, %v; want %v, %v",
+					tt.input, dur, ok, tt.expected, tt.ok)
+			}
+		})
+	}
+}

--- a/isNumber.go
+++ b/isNumber.go
@@ -4,8 +4,5 @@ import "strconv"
 
 func isNumber(str string) bool {
 	_, err := strconv.Atoi(str)
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }

--- a/isNumber_test.go
+++ b/isNumber_test.go
@@ -1,0 +1,28 @@
+package timeperiod
+
+import (
+	"testing"
+)
+
+func Test_isNumber(t *testing.T) {
+	type args struct {
+		str string
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"number", args{"7"}, true},
+		{"string", args{"syv"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNumber(tt.args.str); got != tt.want {
+				t.Errorf("isNumber() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/splitValueAndUnit.go
+++ b/splitValueAndUnit.go
@@ -1,18 +1,23 @@
 package timeperiod
 
+import (
+	"unicode/utf8"
+)
+
 func splitValueAndUnit(period string) (valueAsStr string, unit string) {
 	strLength := len(period)
+	unitStrLength := 0
 
-	lastChar := period[strLength-1:]
-	if isNumber(lastChar) {
+	lastChar, size := utf8.DecodeLastRuneInString(period)
+	unitStrLength += size
+	if isNumber(string(lastChar)) {
 		valueAsStr = period
 		return
 	}
 
-	unitStrLength := 1
-	nextToLastChar := period[strLength-2 : strLength-1]
-	if !isNumber(nextToLastChar) {
-		unitStrLength = 2
+	nextToLastChar, size := utf8.DecodeLastRuneInString(period[:strLength-size])
+	if !isNumber(string(nextToLastChar)) {
+		unitStrLength += size
 	}
 
 	position := strLength - unitStrLength


### PR DESCRIPTION
Allowing `µs` in addition to `us` as unit for microseconds.